### PR TITLE
Enable Cosmic

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,10 +9,7 @@ peers:
   magpie:
     interface: magpie
 series:
-  - artful
-  - zesty
   - xenial
   - trusty
-  - precise
-  - yakkety
   - bionic
+  - cosmic


### PR DESCRIPTION
This change removes support for EOL Ubuntu series
as well as adding the newer Cosmic release.