### PR TITLE
Sort output of 'icmp failed' status message

### DIFF
--- a/lib/charms/layer/magpie_tools.py
+++ b/lib/charms/layer/magpie_tools.py
@@ -222,7 +222,7 @@ def check_ping(nodes):
     except NameError:
         unreachable = []
     for node in nodes:
-        unit_id = node[0].split('/')[1]
+        unit_id = int(node[0].split('/')[1])
         hookenv.log('Pinging unit_id: ' + str(unit_id), 'INFO')
         if ping(node[1], ping_time, ping_tries) == 1:
             hookenv.log('Ping FAILED for unit_id: ' + str(unit_id), 'ERROR')
@@ -233,7 +233,7 @@ def check_ping(nodes):
             if unit_id in unreachable:
                 unreachable.remove(unit_id)
 
-    return unreachable
+    return sorted(unreachable)
 
 
 def check_dns(nodes):


### PR DESCRIPTION
This commit updates the output of 'icmp failed' status message:
  - the list is sorted,
  - apostrphes are removed.

Example:
Before: "icmp failed: ['0', '9', '3', '6', '7', '5', '11', '12']"
After:  "icmp failed: [0, 3, 5, 6, 7, 9, 11, 12]"

Sorting the list makes it easier to troubleshoot and spot the patterns.
Removing apostropes makes the status line shorter and easier to read.